### PR TITLE
Separate SparkSession and create DataFrames from input files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ bin/
 # mac
 .DS_Store
 
+#spark
+spark-warehouse
+
 # other?
 .history
 .scala_dependencies

--- a/src/main/scala/Start.scala
+++ b/src/main/scala/Start.scala
@@ -1,22 +1,22 @@
 import org.apache.spark.sql.SparkSession
 
-object Start {
-  val spark = SparkSession
-    .builder
-    .appName("hello hive")
-    .config("spark.master", "local")
-    .enableHiveSupport()
-    .getOrCreate()
+import session.spark.LocalSparkSession
+import covid.tables.DFTables
 
+object Start {
+  val spark = LocalSparkSession()
 
   def main(args: Array[String]): Unit = {
     // create a spark session
     // for Windows
-    System.setProperty("hadoop.home.dir", "C:\\winutils")
     spark.sparkContext.setLogLevel("WARN") //reduces terminal clutter
     println("created spark session")
 
     println("Hello, world! this is a new line")
 
+    //Testing table creation -- asserting that the headers were read as column names
+    DFTables.getCOVID_19Recovered.select("Province/State").show()
+
+    System.exit(0)
   }
 }

--- a/src/main/scala/covid/tables/DFTables.scala
+++ b/src/main/scala/covid/tables/DFTables.scala
@@ -1,0 +1,27 @@
+package covid.tables
+
+import org.apache.spark.sql.{SparkSession, DataFrame}
+import session.spark.LocalSparkSession
+
+object DFTables {
+    private var c19DataRP       = "input/covid_19_data.csv"
+    private var tsc19Conf       = "input/time_series_covid_19_confirmed.csv"
+    private var tsc19ConfUS     = "input/time_series_covid_19_confirmed_US.csv"
+    private var tsc19Deaths     = "input/time_series_covid_19_deaths.csv"
+    private var tsc19DeathsUS   = "input/time_series_covid_19_deaths_US.csv"
+    private var tsc19Recovered  = "input/time_series_covid_19_recovered.csv"
+
+    private var lss             = LocalSparkSession()
+
+    def getCOVID_19Data: DataFrame = lss.read.option("header", true).csv(c19DataRP)
+
+    def getCOVID_19Confirmed: DataFrame = lss.read.option("header", true).csv(tsc19Conf)
+
+    def getCOVID_19ConfirmedUS: DataFrame = lss.read.option("header", true).csv(tsc19ConfUS)
+
+    def getCOVID_19Deaths: DataFrame = lss.read.option("header", true).csv(tsc19Deaths)
+
+    def getCOVID_19DeathsUS: DataFrame = lss.read.option("header", true).csv(tsc19DeathsUS)
+
+    def getCOVID_19Recovered: DataFrame = lss.read.option("header", true).csv(tsc19Recovered)
+}

--- a/src/main/scala/session/spark/LocalSparkSession.scala
+++ b/src/main/scala/session/spark/LocalSparkSession.scala
@@ -1,0 +1,26 @@
+package session.spark
+
+import org.apache.spark.sql.SparkSession
+
+object LocalSparkSession {
+    private var lss: SparkSession   = null
+
+    private val app_name            = "hello hive"
+    private val spark_master_set    = "spark.master"
+    private val spark_master        = "local"
+    private val hadoop_home_set     = "hadoop.home.dir"
+    private val hadoop_home         = "C:\\winutils"
+
+    def apply(): SparkSession = if (lss == null) {lss = createSession; lss} else lss
+
+    private def createSession: SparkSession = {
+        System.setProperty(hadoop_home_set, hadoop_home)
+
+        SparkSession
+        .builder
+        .appName(app_name)
+        .config(spark_master_set, spark_master)
+        .enableHiveSupport()
+        .getOrCreate()
+    }
+}


### PR DESCRIPTION
Brief Summary of Important Changes:
- Separated SparkSession configuration; it can now be obtained from session.spark.LocalSparkSession by calling LocalSparkSession()
- All tables have been created in DataFrame format; please look at covid.tables.DFTables for method headers
- Added spark-warehouse to .gitignore to minimize clutter on the github repo